### PR TITLE
Add CI workflow for iOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Run unit tests
+        run: |
+          xcodebuild test \
+            -workspace Morsel.xcodeproj/project.xcworkspace \
+            -scheme iOS \
+            -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' \
+            CODE_SIGNING_ALLOWED=NO
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run unit tests
         run: |
           xcodebuild test \
-            -workspace Morsel.xcodeproj/project.xcworkspace \
+            -project Morsel.xcodeproj \
             -scheme iOS \
             -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' \
             CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to execute unit tests on pull requests

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688c8e7b87b8832ca09dd9eb7412d4a2