### PR TITLE
Update AGENTS to note iOS 26

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository follows a default template for top-notch iOS engineering. These 
 - Keep line length under **120 characters** when possible.
 - Prefer structs and value types where appropriate.
 - Group related extensions together using `// MARK:` comments.
+- Place private methods and variables in a `private` extension on the enclosing type whenever possible.
 
 ## Commit Messages
 - Write informative commit messages in present tense (e.g., "Add loading state to StatsView").

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS
+
+This repository follows a default template for top-notch iOS engineering. These instructions apply to all files unless overridden by a nested `AGENTS.md`.
+
+## General Principles
+- Code must be written in Swift using modern iOS development practices.
+- Aim for clear, concise code with comments where necessary.
+- Keep functions small and focused on a single responsibility.
+- Use `@MainActor` when performing UI-related tasks.
+- Target **iOS 26** and make use of its APIs where beneficial.
+
+## Code Style
+- Indentation uses **two spaces**. No tabs.
+- Keep line length under **120 characters** when possible.
+- Prefer structs and value types where appropriate.
+- Group related extensions together using `// MARK:` comments.
+
+## Commit Messages
+- Write informative commit messages in present tense (e.g., "Add loading state to StatsView").
+- Include a short description followed by an optional blank line and more details.
+
+## Pull Requests
+- Summarize any user-facing or developer-facing changes.
+- Mention testing performed, even if minimal.
+- Run any available linters. If none are present, at least build the project to ensure there are no syntax errors.
+
+


### PR DESCRIPTION
## Summary
- update the AGENTS guidelines
  - mention the iOS 26 deployment target
  - remove the reference to `swiftlint`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688ce55c9cdc832cb833c94a6c0989a2