### PR TITLE
Add onboarding modal triggered by first Morsel tap

### DIFF
--- a/iOS/Views/OnboardingView.swift
+++ b/iOS/Views/OnboardingView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct OnboardingView: View {
+  var onDone: () -> Void
+
+  var body: some View {
+    VStack {
+      Spacer()
+      Button("Done with onboarding") {
+        onDone()
+      }
+      Spacer()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+


### PR DESCRIPTION
## Summary
- hide UI elements on first launch until onboarding is completed
- show onboarding sheet when Morsel is tapped for the first time
- add simple onboarding view with dismissal button

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e5980ad04832ca2bfb6afa2678822