### PR TITLE
Add CI workflow for Core tests

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -1,0 +1,16 @@
+name: CoreTests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Core tests
+        run: |
+          xcodebuild test \
+            -project Morsel.xcodeproj \
+            -scheme CoreTests \
+            -destination 'platform=iOS Simulator,OS=17.5,name=iPhone 15'

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -7,6 +7,9 @@ jobs:
   test:
     runs-on: macos-latest
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26"
       - uses: actions/checkout@v4
       - name: Run Core tests
         run: |

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -15,4 +15,4 @@ jobs:
           xcodebuild test \
             -project Morsel.xcodeproj \
             -scheme CoreTests \
-            -destination 'platform=iOS Simulator,OS=26.0,name=iPhone 15'
+            -destination 'platform=iOS Simulator,OS=26.0,name=iPhone 16'

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -5,15 +5,14 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26"
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
       - uses: actions/checkout@v4
       - name: Run Core tests
         run: |
           xcodebuild test \
             -project Morsel.xcodeproj \
             -scheme CoreTests \
-            -destination 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
+            -destination 'platform=iOS Simulator,OS=26.0,name=iPhone 15'


### PR DESCRIPTION
## Summary
- run CoreTests scheme on pull requests using GitHub Actions

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f2394c8e8832c8583a5afa211aae3