### PR TITLE
Add CI workflow for Core tests

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -1,0 +1,20 @@
+name: CoreTests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
+      - name: Install iOS 26 simulator
+        run: sudo xcodebuild -downloadPlatform iOS
+      - name: Run Core tests
+        run: |
+          xcodebuild test \
+            -project Morsel.xcodeproj \
+            -scheme CoreTests \
+            -destination 'platform=iOS Simulator,OS=26.0,name=iPhone 16'


### PR DESCRIPTION
## Summary
- run CoreTests scheme on pull requests using GitHub Actions
- select Xcode 26 and install the iOS 26 simulator runtime before running tests

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f2394c8e8832c8583a5afa211aae3