### PR TITLE
Move AppSettings into CoreMorsel and invert watch sync dependency

### DIFF
--- a/CoreMorsel/Sources/CoreMorsel/Extensions/NotificationName+Morsel.swift
+++ b/CoreMorsel/Sources/CoreMorsel/Extensions/NotificationName+Morsel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public extension Notification.Name {
+  static let didReceiveMorselColor = Notification.Name("didReceiveMorselColor")
+}

--- a/CoreMorsel/Sources/CoreMorsel/Settings/AppSettings.swift
+++ b/CoreMorsel/Sources/CoreMorsel/Settings/AppSettings.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 import WidgetKit
 
-enum Key: String {
+public enum Key: String {
   case morselColor
   case morselColorRGBA
   case appTheme

--- a/CoreMorsel/Sources/CoreMorsel/Settings/AppSettings.swift
+++ b/CoreMorsel/Sources/CoreMorsel/Settings/AppSettings.swift
@@ -1,7 +1,5 @@
-import CoreMorsel
 import Foundation
 import SwiftUI
-import WatchConnectivity
 import WidgetKit
 
 enum Key: String {
@@ -10,12 +8,12 @@ enum Key: String {
   case appTheme
 }
 
-enum AppTheme: String, CaseIterable {
+public enum AppTheme: String, CaseIterable {
   case system = "system"
   case light = "light"
   case dark = "dark"
   
-  var displayName: String {
+  public var displayName: String {
     switch self {
     case .system: return "System"
     case .light: return "Light"
@@ -23,7 +21,7 @@ enum AppTheme: String, CaseIterable {
     }
   }
   
-  var colorScheme: ColorScheme? {
+  public var colorScheme: ColorScheme? {
     switch self {
     case .system: return nil
     case .light: return .light
@@ -32,29 +30,29 @@ enum AppTheme: String, CaseIterable {
   }
 }
 
-class AppSettings: ObservableObject {
-  static let shared = AppSettings()
+public final class AppSettings: ObservableObject {
+  public static let shared = AppSettings()
   private let defaults = UserDefaults(suiteName: appGroupIdentifier)
 
   private static let fallbackColor: Color = .blue
 
-  @Published var showDigest = false
+  @Published public var showDigest = false
 
-  @Published var appTheme: AppTheme {
+  @Published public var appTheme: AppTheme {
     didSet {
       defaults?.set(appTheme.rawValue, forKey: Key.appTheme.rawValue)
     }
   }
 
-  @Published var morselColor: Color {
+  @Published public var morselColor: Color {
     didSet {
       saveColorToUserDefaults(morselColor)
       WidgetCenter.shared.reloadAllTimelines()
-#if os(iOS)
-      PhoneSessionManager.shared.notifyWatchOfNewColor(morselColor)
-#endif
+      onMorselColorChange?(morselColor)
     }
   }
+
+  public var onMorselColorChange: ((Color) -> Void)?
 
   private init() {
     let initialColor = AppSettings.loadInitialColor(from: defaults)

--- a/Debug/MorselStudio.swift
+++ b/Debug/MorselStudio.swift
@@ -1,3 +1,4 @@
+import CoreMorsel
 import SwiftUI
 
 struct MorselStudio: View {

--- a/Morsel.xcodeproj/project.pbxproj
+++ b/Morsel.xcodeproj/project.pbxproj
@@ -144,8 +144,7 @@
 				"Resources/Fonts/Quicksand-Medium.ttf",
 				"Resources/Fonts/Quicksand-Regular.ttf",
 				"Resources/Fonts/Quicksand-SemiBold.ttf",
-				Settings/AppSettings.swift,
-				UI/BackgroundGradientView.swift,
+                                UI/BackgroundGradientView.swift,
 			);
 			target = A3CD694B2DBF752B00AB946D /* Widgets (iOS) */;
 		};
@@ -160,8 +159,7 @@
 				"Resources/Fonts/Quicksand-Medium.ttf",
 				"Resources/Fonts/Quicksand-Regular.ttf",
 				"Resources/Fonts/Quicksand-SemiBold.ttf",
-				Settings/AppSettings.swift,
-			);
+                        );
 			target = A35D3CD52DBFB0B100C4C166 /* Morsel (watchOS) */;
 		};
 		A384150C2DD097F700980E9E /* Exceptions for "iOS" folder in "Widgets (iOS)" target */ = {

--- a/MorselCore/UI/BackgroundGradientView.swift
+++ b/MorselCore/UI/BackgroundGradientView.swift
@@ -1,3 +1,4 @@
+import CoreMorsel
 import SwiftUI
 import UIKit
 

--- a/iOS/Managers/PhoneSessionManager.swift
+++ b/iOS/Managers/PhoneSessionManager.swift
@@ -13,6 +13,9 @@ class PhoneSessionManager: NSObject, WCSessionDelegate, ObservableObject {
       WCSession.default.delegate = self
       WCSession.default.activate()
     }
+    AppSettings.shared.onMorselColorChange = { [weak self] color in
+      self?.notifyWatchOfNewColor(color)
+    }
   }
   
   func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {

--- a/iOS/Views/Helpers/ToggleButton.swift
+++ b/iOS/Views/Helpers/ToggleButton.swift
@@ -1,3 +1,4 @@
+import CoreMorsel
 import SwiftUI
 
 struct ToggleButton: View {

--- a/iOS/Views/ThemePickerView.swift
+++ b/iOS/Views/ThemePickerView.swift
@@ -1,3 +1,4 @@
+import CoreMorsel
 import SwiftUI
 
 struct ThemePickerView: View {

--- a/iOS/Widgets/FoodEntryWidget.swift
+++ b/iOS/Widgets/FoodEntryWidget.swift
@@ -1,3 +1,4 @@
+import CoreMorsel
 import WidgetKit
 import SwiftUI
 import SwiftData

--- a/watchOS/Managers/WatchSessionManager.swift
+++ b/watchOS/Managers/WatchSessionManager.swift
@@ -76,7 +76,3 @@ class WatchSessionManager: NSObject, WCSessionDelegate, ObservableObject {
 
   func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: (any Error)?) {}
 }
-
-extension Notification.Name {
-  static let didReceiveMorselColor = Notification.Name("didReceiveMorselColor")
-}


### PR DESCRIPTION
## Summary
- Move AppSettings into CoreMorsel package and expose AppTheme and AppSettings publicly
- Replace direct PhoneSessionManager call with color-change closure and hook it up in PhoneSessionManager
- Centralize didReceiveMorselColor notification in CoreMorsel and update imports

## Testing
- `swift build` *(fails: no such module 'CommonCrypto')*
- `xcodebuild -list` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890a73fa8b4832cbaa10a7146639cf2