### PR TITLE
Move MorselView into CoreMorsel

### DIFF
--- a/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
+++ b/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
@@ -1,34 +1,55 @@
-import CoreMorsel
 import SwiftUI
 
-enum MorselDebugControlMode {
+public enum MorselDebugControlMode {
   case automatic
   case manual
 }
 
-struct MorselDebugBindings {
-  var isBlinking: Binding<Bool>?
-  var isSwallowing: Binding<Bool>?
-  var idleOffset: Binding<CGSize>?
-  var idleLookaroundOffset: Binding<CGFloat>?
+public struct MorselDebugBindings {
+  public var isBlinking: Binding<Bool>?
+  public var isSwallowing: Binding<Bool>?
+  public var idleOffset: Binding<CGSize>?
+  public var idleLookaroundOffset: Binding<CGFloat>?
+
+  public init(
+    isBlinking: Binding<Bool>? = nil,
+    isSwallowing: Binding<Bool>? = nil,
+    idleOffset: Binding<CGSize>? = nil,
+    idleLookaroundOffset: Binding<CGFloat>? = nil
+  ) {
+    self.isBlinking = isBlinking
+    self.isSwallowing = isSwallowing
+    self.idleOffset = idleOffset
+    self.idleLookaroundOffset = idleLookaroundOffset
+  }
 }
 
-struct AnimatedEyeView: View {
+public struct AnimatedEyeView: View {
   @Binding var amount: CGFloat
   @Binding var angle: Angle
 
-  var body: some View {
+  public init(amount: Binding<CGFloat>, angle: Binding<Angle>) {
+    _amount = amount
+    _angle = angle
+  }
+
+  public var body: some View {
     EyebrowedEyeShape(eyebrowAmount: amount, angle: angle)
       .fill(Color(uiColor: UIColor(red: 0.07, green: 0.20, blue: 0.37, alpha: 1.00)))
       .animation(.easeInOut(duration: 0.3), value: amount)
   }
 }
 
-struct EyebrowedEyeShape: Shape {
-  var eyebrowAmount: CGFloat // 0 = circle, 1 = flat segment
-  var angle: Angle // angle of flat segment
+public struct EyebrowedEyeShape: Shape {
+  public var eyebrowAmount: CGFloat // 0 = circle, 1 = flat segment
+  public var angle: Angle // angle of flat segment
 
-  var animatableData: AnimatablePair<CGFloat, CGFloat> {
+  public init(eyebrowAmount: CGFloat, angle: Angle) {
+    self.eyebrowAmount = eyebrowAmount
+    self.angle = angle
+  }
+
+  public var animatableData: AnimatablePair<CGFloat, CGFloat> {
     get { AnimatablePair(eyebrowAmount, CGFloat(angle.degrees)) }
     set {
       eyebrowAmount = newValue.first
@@ -36,7 +57,7 @@ struct EyebrowedEyeShape: Shape {
     }
   }
 
-  func path(in rect: CGRect) -> Path {
+  public func path(in rect: CGRect) -> Path {
     let clamped = min(max(eyebrowAmount, 0), 1)
     let radius = min(rect.width, rect.height) / 2
     let center = CGPoint(x: rect.midX, y: rect.midY)
@@ -83,7 +104,7 @@ struct EyebrowedEyeShape: Shape {
 }
 
 
-struct MorselView: View {
+public struct MorselView: View {
   @Binding var shouldOpen: Bool
   @Binding var shouldClose: Bool
   @Binding var isChoosingDestination: Bool
@@ -102,7 +123,7 @@ struct MorselView: View {
   @State private var playSpeechBubbleAnimation = false
 
   @State private var didTriggerLongPress = false
-  
+
   @State private var dragOffset: CGSize = .zero
 
   @FocusState private var isFocused: Bool
@@ -115,6 +136,32 @@ struct MorselView: View {
 
   var debugBindings: MorselDebugBindings? = nil
   var debugControlMode: MorselDebugControlMode = .automatic
+
+  public init(
+    shouldOpen: Binding<Bool>,
+    shouldClose: Binding<Bool>,
+    isChoosingDestination: Binding<Bool>,
+    destinationProximity: Binding<CGFloat>,
+    isLookingUp: Binding<Bool>,
+    morselColor: Color,
+    supportsOpen: Bool = true,
+    onTap: (() -> Void)? = nil,
+    onAdd: @escaping (String) -> Void,
+    debugBindings: MorselDebugBindings? = nil,
+    debugControlMode: MorselDebugControlMode = .automatic
+  ) {
+    _shouldOpen = shouldOpen
+    _shouldClose = shouldClose
+    _isChoosingDestination = isChoosingDestination
+    _destinationProximity = destinationProximity
+    _isLookingUp = isLookingUp
+    self.morselColor = morselColor
+    self.supportsOpen = supportsOpen
+    self.onTap = onTap
+    self.onAdd = onAdd
+    self.debugBindings = debugBindings
+    self.debugControlMode = debugControlMode
+  }
 
   private var isSwallowing: Bool {
     switch debugControlMode {
@@ -152,7 +199,7 @@ struct MorselView: View {
     }
   }
 
-  var body: some View {
+  public var body: some View {
     ZStack(alignment: .bottom) {
       SpeechBubble(isOpen: $isOpen, isBeingTouched: $isBeingTouched, playAnimation: $playSpeechBubbleAnimation)
         .offset(y: -80)
@@ -570,7 +617,7 @@ struct MorselView: View {
   
 }
 
-struct SpeechBubble: View {
+public struct SpeechBubble: View {
   @Binding var isOpen: Bool
   @Binding var isBeingTouched: Bool
   @Binding var playAnimation: Bool
@@ -581,6 +628,16 @@ struct SpeechBubble: View {
   @State private var showSmallBubble = false
   @State private var showMediumBubble = false
   @State private var showMainBubble = false
+
+  public init(
+    isOpen: Binding<Bool>,
+    isBeingTouched: Binding<Bool>,
+    playAnimation: Binding<Bool>
+  ) {
+    _isOpen = isOpen
+    _isBeingTouched = isBeingTouched
+    _playAnimation = playAnimation
+  }
 
   private let phrases = [
     "Hey there! 👋",
@@ -597,7 +654,7 @@ struct SpeechBubble: View {
     "Small bites, big wins"
   ]
 
-  var body: some View {
+  public var body: some View {
     ZStack {
       VStack {
         // Main bubble

--- a/Morsel.xcodeproj/project.pbxproj
+++ b/Morsel.xcodeproj/project.pbxproj
@@ -16,8 +16,6 @@
 		A35984FE2E40CB1F007679F3 /* CoreMorsel in Frameworks */ = {isa = PBXBuildFile; productRef = A35984FD2E40CB1F007679F3 /* CoreMorsel */; };
 		A35985002E40CB23007679F3 /* CoreMorsel in Frameworks */ = {isa = PBXBuildFile; productRef = A35984FF2E40CB23007679F3 /* CoreMorsel */; };
 		A35985022E40CB27007679F3 /* CoreMorsel in Frameworks */ = {isa = PBXBuildFile; productRef = A35985012E40CB27007679F3 /* CoreMorsel */; };
-		A35989812E40EDA8007679F3 /* MorselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A359897E2E40EDA8007679F3 /* MorselView.swift */; };
-		A35989832E40EDC0007679F3 /* MorselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A359897E2E40EDA8007679F3 /* MorselView.swift */; };
 		A35D3CF62DBFB0B300C4C166 /* Morsel (watchOS).app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = A35D3CD62DBFB0B100C4C166 /* Morsel (watchOS).app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A36333E92DC94B7500DD9ADA /* TODO.txt in Sources */ = {isa = PBXBuildFile; fileRef = A36333E82DC94B7500DD9ADA /* TODO.txt */; };
 		A36479442DCC948200A2F723 /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = A36479432DCC948200A2F723 /* TelemetryDeck */; };
@@ -127,7 +125,6 @@
 		A329C33E2E3F586A001D158E /* iOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A329C34D2E3F587E001D158E /* watchOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = watchOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A35982712E40C068007679F3 /* Morsel.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Morsel.xctestplan; sourceTree = "<group>"; };
-		A359897E2E40EDA8007679F3 /* MorselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorselView.swift; sourceTree = "<group>"; };
 		A35D3CD62DBFB0B100C4C166 /* Morsel (watchOS).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Morsel (watchOS).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A36333E82DC94B7500DD9ADA /* TODO.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = TODO.txt; sourceTree = "<group>"; };
 		A3AE569A2DC2731800608E0D /* Widgets (watchOS).appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Widgets (watchOS).appex"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -366,7 +363,6 @@
 		A3CD68FB2DBF745E00AB946D = {
 			isa = PBXGroup;
 			children = (
-				A359897E2E40EDA8007679F3 /* MorselView.swift */,
 				A3CD69062DBF745E00AB946D /* iOS */,
 				A329C3252E3F57FC001D158E /* iOSTests */,
 				A329C33F2E3F586A001D158E /* iOSUITests */,
@@ -781,14 +777,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A35D3CD22DBFB0B100C4C166 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A35989832E40EDC0007679F3 /* MorselView.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                A35D3CD22DBFB0B100C4C166 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		A3AE56962DC2731800608E0D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -796,15 +791,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A3CD69002DBF745E00AB946D /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A36333E92DC94B7500DD9ADA /* TODO.txt in Sources */,
-				A35989812E40EDA8007679F3 /* MorselView.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                A3CD69002DBF745E00AB946D /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                A36333E92DC94B7500DD9ADA /* TODO.txt in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		A3CD69482DBF752B00AB946D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
## Summary
- relocate `MorselView` and related views into the `CoreMorsel` package
- expose public initialisers for the SwiftUI views
- remove old file references from the Xcode project

## Testing
- `swift build` *(fails: no such module 'CommonCrypto')*

------
https://chatgpt.com/codex/tasks/task_e_6890b6f9c254832cae3108cc63c85dd5