### PR TITLE
Add unit tests for CoreMorsel

### DIFF
--- a/CoreMorsel/Tests/CoreMorselTests/Analytics/AnalyticsTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Analytics/AnalyticsTests.swift
@@ -1,0 +1,36 @@
+@testable import CoreMorsel
+import Foundation
+import Testing
+
+struct AnalyticsTests {
+  @Test func eventDefaultsToEmptyParameters() async throws {
+    struct TestEvent: Event { let name = "test" }
+    let event = TestEvent()
+    #expect(event.parameters.isEmpty)
+  }
+
+  @Test func logForMorselEventHasExpectedParameters() async throws {
+    let date = Date(timeIntervalSince1970: 0)
+    let event = LogForMorselEvent(craving: "Cake", timestamp: date, context: "app")
+    #expect(event.name == "log_for_morsel")
+    #expect(event.parameters["name"] == "Cake")
+    #expect(event.parameters["timestamp"] == date.isoString)
+    #expect(event.parameters["context"] == "app")
+  }
+
+  @Test func screenViewEventBuildsName() async throws {
+    struct HomeScreen: ScreenViewEvent { let screenName = "Home" }
+    let event = HomeScreen()
+    #expect(event.name == "ScreenView_Home")
+    #expect(event.parameters.isEmpty)
+  }
+
+  @Test func screenViewEventIncludesAdditionalParameters() async throws {
+    struct StatsScreen: ScreenViewEvent {
+      let screenName = "Stats"
+      let additionalParameters: EventParameters = ["foo": "bar"]
+    }
+    let event = StatsScreen()
+    #expect(event.parameters["foo"] == "bar")
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Extensions/Color+UtilitiesTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Extensions/Color+UtilitiesTests.swift
@@ -1,0 +1,21 @@
+@testable import CoreMorsel
+import SwiftUI
+import Testing
+
+struct ColorUtilitiesTests {
+  @Test func darkensColorByPercentage() async throws {
+    let original = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.6, opacity: 1)
+    let darkened = Color.darkened(from: original, percentage: 0.5)
+
+    var oHue: CGFloat = 0, oSat: CGFloat = 0, oBright: CGFloat = 0, oAlpha: CGFloat = 0
+    var dHue: CGFloat = 0, dSat: CGFloat = 0, dBright: CGFloat = 0, dAlpha: CGFloat = 0
+
+    UIColor(original).getHue(&oHue, saturation: &oSat, brightness: &oBright, alpha: &oAlpha)
+    UIColor(darkened).getHue(&dHue, saturation: &dSat, brightness: &dBright, alpha: &dAlpha)
+
+    #expect(oHue == dHue)
+    #expect(oSat == dSat)
+    #expect(abs(dBright - (oBright * 0.5)) < 0.0001)
+    #expect(oAlpha == dAlpha)
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Extensions/NotificationName+MorselTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Extensions/NotificationName+MorselTests.swift
@@ -1,0 +1,9 @@
+@testable import CoreMorsel
+import Foundation
+import Testing
+
+struct NotificationNameMorselTests {
+  @Test func hasExpectedRawValue() async throws {
+    #expect(Notification.Name.didReceiveMorselColor.rawValue == "didReceiveMorselColor")
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Extensions/UIColor+UtilitiesTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Extensions/UIColor+UtilitiesTests.swift
@@ -1,0 +1,15 @@
+@testable import CoreMorsel
+import UIKit
+import Testing
+
+struct UIColorUtilitiesTests {
+  @Test func returnsRGBAComponents() async throws {
+    let color = UIColor(red: 0.2, green: 0.4, blue: 0.6, alpha: 0.8)
+    let components = color.rgba
+    #expect(components.count == 4)
+    #expect(abs(components[0] - 0.2) < 0.0001)
+    #expect(abs(components[1] - 0.4) < 0.0001)
+    #expect(abs(components[2] - 0.6) < 0.0001)
+    #expect(abs(components[3] - 0.8) < 0.0001)
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Model/ModelContextDeleteAllTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Model/ModelContextDeleteAllTests.swift
@@ -1,0 +1,23 @@
+@testable import CoreMorsel
+import SwiftData
+import Testing
+
+@MainActor
+struct ModelContextDeleteAllTests {
+  @Test func removesAllObjects() async throws {
+    let container = try ModelContainer(for: [FoodEntry.self])
+    let context = container.mainContext
+
+    context.insert(FoodEntry(name: "A", isForMorsel: false))
+    context.insert(FoodEntry(name: "B", isForMorsel: true))
+    try context.save()
+    let before = try context.fetch(FetchDescriptor<FoodEntry>()).count
+    #expect(before == 2)
+
+    let result = context.deleteAll(FoodEntry.self)
+    #expect(result)
+
+    let after = try context.fetch(FetchDescriptor<FoodEntry>()).count
+    #expect(after == 0)
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Settings/AppSettingsTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Settings/AppSettingsTests.swift
@@ -1,0 +1,46 @@
+@testable import CoreMorsel
+import SwiftUI
+import Testing
+
+@MainActor
+struct AppSettingsTests {
+  @Test func savesColorToUserDefaults() async throws {
+    let defaults = UserDefaults(suiteName: appGroupIdentifier)
+    let settings = AppSettings.shared
+    let originalColor = settings.morselColor
+    defer {
+      settings.morselColor = originalColor
+      defaults?.removeObject(forKey: Key.morselColorRGBA.rawValue)
+      defaults?.removeObject(forKey: Key.morselColor.rawValue)
+    }
+
+    settings.morselColor = .red
+    let rgba = defaults?.array(forKey: Key.morselColorRGBA.rawValue) as? [Double]
+    #expect(rgba == [1, 0, 0, 1])
+  }
+
+  @Test func persistsAppTheme() async throws {
+    let defaults = UserDefaults(suiteName: appGroupIdentifier)
+    let settings = AppSettings.shared
+    let originalTheme = settings.appTheme
+    defer {
+      settings.appTheme = originalTheme
+      defaults?.removeObject(forKey: Key.appTheme.rawValue)
+    }
+
+    settings.appTheme = .dark
+    let stored = defaults?.string(forKey: Key.appTheme.rawValue)
+    #expect(stored == AppTheme.dark.rawValue)
+  }
+
+  @Test func invokesColorChangeCallback() async throws {
+    let settings = AppSettings.shared
+    let originalColor = settings.morselColor
+    defer { settings.morselColor = originalColor }
+
+    var called = false
+    settings.onMorselColorChange = { _ in called = true }
+    settings.morselColor = .green
+    #expect(called)
+  }
+}


### PR DESCRIPTION
## Summary
- add tests for color utilities and notification names
- cover AppSettings persistence and callbacks
- verify analytics events and model context deletion

## Testing
- `xcodebuild -scheme CoreMorsel -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' test` (command not found)
- `swift test` (fails: no such module 'CommonCrypto')

------
https://chatgpt.com/codex/tasks/task_e_6890be3e7cc0832c848e4836ad4dc179