### PR TITLE
Add unit tests for model and extensions

### DIFF
--- a/CoreMorsel/Tests/CoreMorselTests/Extensions/NotificationName+MorselTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Extensions/NotificationName+MorselTests.swift
@@ -1,0 +1,9 @@
+@testable import CoreMorsel
+import Foundation
+import Testing
+
+struct NotificationNameMorselTests {
+  @Test func didReceiveMorselColorRawValue() async throws {
+    #expect(Notification.Name.didReceiveMorselColor.rawValue == "didReceiveMorselColor")
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Extensions/UIColor+UtilitiesTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Extensions/UIColor+UtilitiesTests.swift
@@ -1,0 +1,14 @@
+@testable import CoreMorsel
+import UIKit
+import Testing
+
+struct UIColorUtilitiesTests {
+  @Test func rgbaReturnsComponents() async throws {
+    let color = UIColor(red: 0.25, green: 0.5, blue: 0.75, alpha: 0.5)
+    let components = color.rgba
+    #expect(components[0] == 0.25)
+    #expect(components[1] == 0.5)
+    #expect(components[2] == 0.75)
+    #expect(components[3] == 0.5)
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Model/AddContextTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Model/AddContextTests.swift
@@ -1,0 +1,20 @@
+@testable import CoreMorsel
+import Foundation
+import Testing
+
+struct AddContextTests {
+  @Test func rawValuesMatchCaseNames() async throws {
+    #expect(AddContext.phoneApp.rawValue == "phoneApp")
+    #expect(AddContext.phoneWidget.rawValue == "phoneWidget")
+    #expect(AddContext.phoneIntent.rawValue == "phoneIntent")
+    #expect(AddContext.phoneFromWatch.rawValue == "phoneFromWatch")
+    #expect(AddContext.watchApp.rawValue == "watchApp")
+    #expect(AddContext.watchFromPhone.rawValue == "watchFromPhone")
+  }
+
+  @Test func initialisesFromRawValue() async throws {
+    for context in [AddContext.phoneApp, .phoneWidget, .phoneIntent, .phoneFromWatch, .watchApp, .watchFromPhone] {
+      #expect(AddContext(rawValue: context.rawValue) == context)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- test AddContext raw values and initialisation
- verify Notification.Name.didReceiveMorselColor raw value
- ensure UIColor.rgba returns expected components

## Testing
- `swift build` *(fails: no such module 'SwiftUI'; no such module 'CommonCrypto')*

------
https://chatgpt.com/codex/tasks/task_e_6891d84cb8ac832ca0ca00bc27511802