### PR TITLE
Add initial tests for CoreMorsel analytics layer

### DIFF
--- a/CoreMorsel/Tests/CoreMorselTests/Analytics/AnalyticsTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Analytics/AnalyticsTests.swift
@@ -1,4 +1,5 @@
 @testable import CoreMorsel
+import Foundation
 import Testing
 
 struct AnalyticsTests {

--- a/CoreMorsel/Tests/CoreMorselTests/Analytics/AnalyticsTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Analytics/AnalyticsTests.swift
@@ -1,0 +1,19 @@
+@testable import CoreMorsel
+import Testing
+
+struct AnalyticsTests {
+  private struct DummyEvent: Event {
+    let name: String
+    var parameters: EventParameters { ["sample": "value"] }
+  }
+
+  @Test func setupAndTrack() async throws {
+    Analytics.setUp()
+    Analytics.track(DummyEvent(name: "test.event"))
+  }
+
+  @Test func isoStringProducesISO8601() async throws {
+    let date = Date(timeIntervalSince1970: 0)
+    #expect(date.isoString == "1970-01-01T00:00:00Z")
+  }
+}

--- a/CoreMorsel/Tests/CoreMorselTests/Analytics/EventTests.swift
+++ b/CoreMorsel/Tests/CoreMorselTests/Analytics/EventTests.swift
@@ -1,0 +1,23 @@
+@testable import CoreMorsel
+import Testing
+
+struct EventTests {
+  private struct BasicEvent: Event {
+    let name: String
+  }
+
+  private struct CustomEvent: Event {
+    let name: String
+    var parameters: EventParameters { ["foo": "bar"] }
+  }
+
+  @Test func defaultParametersAreEmpty() async throws {
+    let event = BasicEvent(name: "test.event")
+    #expect(event.parameters.isEmpty)
+  }
+
+  @Test func customParametersReturnDictionary() async throws {
+    let event = CustomEvent(name: "test.event")
+    #expect(event.parameters["foo"] == "bar")
+  }
+}


### PR DESCRIPTION
## Summary
- add Event tests covering default and custom parameters
- add Analytics tests exercising tracking and date formatting

## Testing
- `swift build` *(fails: no such module 'SwiftUI'; no such module 'CommonCrypto')*


------
https://chatgpt.com/codex/tasks/task_e_6891dd554974832c9c6b569efe900fb9