### PR TITLE
Add debug menu and fix digest unlock timing

### DIFF
--- a/Debug/DebugMenuView.swift
+++ b/Debug/DebugMenuView.swift
@@ -1,0 +1,61 @@
+#if DEBUG
+import SwiftUI
+import UserNotifications
+
+@MainActor
+struct DebugMenuView: View {
+  @State private var showStudio = false
+
+  var body: some View {
+    NavigationStack {
+      List {
+        Button("Schedule digest") {
+          scheduleDigest()
+        }
+        Button("Morsel Studio") {
+          showStudio = true
+        }
+      }
+      .navigationTitle("Debug")
+      .sheet(isPresented: $showStudio) {
+        MorselStudio()
+      }
+    }
+  }
+
+  private func scheduleDigest() {
+    let calendar = Calendar.current
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+
+    if DigestConfiguration.isDailyDigest {
+      let dayStart = calendar.startOfDay(for: Date())
+      let key = "daily_digest_unlocked_\(formatter.string(from: dayStart))"
+      UserDefaults.standard.removeObject(forKey: key)
+    } else {
+      let weekStart = calendar.startOfWeek(for: Date())
+      let key = "digest_unlocked_\(formatter.string(from: weekStart))"
+      UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    let fireDate = Date().addingTimeInterval(30)
+    NotificationsManager.debugUnlockTime = fireDate
+
+    let content = UNMutableNotificationContent()
+    if DigestConfiguration.isDailyDigest {
+      content.title = "Morsel's got your daily digest!"
+      content.body = "Ready to see how you did today? Morsel's been keeping track."
+    } else {
+      content.title = "Morsel's got your weekly digest!"
+      content.body = "Wanna see how you did this week? Morsel's been watching (politely)."
+    }
+    content.userInfo = ["deepLink": "morsel://digest"]
+    content.sound = .default
+    let center = UNUserNotificationCenter.current()
+    center.removePendingNotificationRequests(withIdentifiers: ["debugDigest"])
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 30, repeats: false)
+    let request = UNNotificationRequest(identifier: "debugDigest", content: content, trigger: trigger)
+    center.add(request)
+  }
+}
+#endif

--- a/iOS/Views/ExtrasView.swift
+++ b/iOS/Views/ExtrasView.swift
@@ -11,6 +11,9 @@ struct ExtrasView: View {
   @State private var showColorSheet = false
   @State private var showIconSheet = false
   @State private var showThemeSheet = false
+#if DEBUG
+  @State private var showDebugMenu = false
+#endif
 
   var onClearAll: () -> Void
 
@@ -52,6 +55,15 @@ struct ExtrasView: View {
           description: "Let us know how Morsel’s doing or what you'd like to see next.",
           onTap: { showFeedbackAlert = true }
         )
+#if DEBUG
+        CardView(
+          title: "",
+          value: "Debug",
+          icon: "ladybug.fill",
+          description: "Developer tools and test actions.",
+          onTap: { showDebugMenu = true }
+        )
+#endif
 #if DEBUG
         CardView(
           title: "",
@@ -118,6 +130,11 @@ struct ExtrasView: View {
           Analytics.track(ScreenViewTheme())
         }
     }
+#if DEBUG
+    .sheet(isPresented: $showDebugMenu) {
+      DebugMenuView()
+    }
+#endif
     .onAppear {
       Analytics.track(ScreenViewExtras())
     }


### PR DESCRIPTION
## Summary
- fix digest unlock delay with a timer that triggers unblur as soon as the unlock time passes
- add a DEBUG-only menu with tools for scheduling digest notifications and launching Morsel Studio
- expose the debug menu from Extras for easier access during development

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc -typecheck iOS/Views/DigestView.swift` *(fails: no such module 'CoreMorsel')*


------
https://chatgpt.com/codex/tasks/task_e_6892fe3f27a0832caf508fec680f2bb1