### PR TITLE
Make glass buttons round across iOS versions

### DIFF
--- a/CoreMorsel/Sources/CoreMorsel/UI/GlassModifier.swift
+++ b/CoreMorsel/Sources/CoreMorsel/UI/GlassModifier.swift
@@ -27,7 +27,12 @@ public extension View {
         self.glassEffect(variant.glass)
       }
     } else {
-      self.glass(displayMode: .automatic)
+      if let shape {
+        self.glass(displayMode: .automatic)
+          .clipShape(shape)
+      } else {
+        self.glass(displayMode: .automatic)
+      }
     }
   }
 

--- a/iOS/Views/Helpers/ToggleButton.swift
+++ b/iOS/Views/Helpers/ToggleButton.swift
@@ -16,7 +16,7 @@ struct ToggleButton: View {
         .frame(width: 44, height: 44)
         .clipShape(Circle())
         .tint(.white)
-        .glass(.regular)
+        .glass(.regular, in: Circle())
     }
     .animation(.easeInOut(duration: 0.25), value: isActive)
   }


### PR DESCRIPTION
## Summary
- ensure glass modifier respects provided shape on pre-iOS 26 so rounded effects stay rounded
- apply circle shape to toggle button glass effect for consistent appearance

## Testing
- `swift build` *(fails: no such module 'CommonCrypto')*


------
https://chatgpt.com/codex/tasks/task_e_68932daadfc8832c8bfe28986931d098