### PR TITLE
Add onboarding skeleton modal

### DIFF
--- a/iOS/Views/ContentView.swift
+++ b/iOS/Views/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
   @State private var recentlyDeleted: FoodEntry?
   @State private var showUndoToast = false
   @State private var undoWorkItem: DispatchWorkItem?
+  @State private var showOnboarding = false
 
   @Binding var shouldOpenMouth: Bool
   @Binding var shouldShowDigest: Bool
@@ -104,7 +105,12 @@ struct ContentView: View {
         .transition(.move(edge: .bottom).combined(with: .opacity))
       }
     }
-    .onAppear { onAppear() }
+    .onAppear {
+      onAppear()
+      if !hasSeenOnboarding {
+        showOnboarding = true
+      }
+    }
     .onReceive(NotificationPublishers.keyboardWillShow) { notification in
       if let height = extractKeyboardHeight(from: notification) {
         withAnimation {
@@ -134,6 +140,12 @@ struct ContentView: View {
     .onReceive(NotificationPublishers.appDidBecomeActive) { _ in }
     .onChange(of: entries.count) { _, new in updateWidget(newCount: new) }
     .statusBarHidden(shouldBlurBackground)
+    .sheet(isPresented: $showOnboarding) {
+      OnboardingView(pages: 3) {
+        hasSeenOnboarding = true
+        showOnboarding = false
+      }
+    }
   }
 }
 

--- a/iOS/Views/ExtrasView.swift
+++ b/iOS/Views/ExtrasView.swift
@@ -11,6 +11,7 @@ struct ExtrasView: View {
   @State private var showColorSheet = false
   @State private var showIconSheet = false
   @State private var showThemeSheet = false
+  @State private var showOnboarding = false
 
   var onClearAll: () -> Void
 
@@ -41,6 +42,13 @@ struct ExtrasView: View {
           icon: "questionmark.app.dashed",
           description: "Choose a different app icon for Morsel.",
           onTap: { showIconSheet = true }
+        )
+        CardView(
+          title: "",
+          value: "Onboarding",
+          icon: "info.circle",
+          description: "View the welcome screens again.",
+          onTap: { showOnboarding = true }
         )
         CardView(
           title: "",
@@ -122,6 +130,11 @@ struct ExtrasView: View {
         .onAppear {
           Analytics.track(ScreenViewIcon())
         }
+    }
+    .sheet(isPresented: $showOnboarding) {
+      OnboardingView(pages: 3) {
+        showOnboarding = false
+      }
     }
     .sheet(isPresented: $showThemeSheet) {
       ThemePickerView()

--- a/iOS/Views/OnboardingView.swift
+++ b/iOS/Views/OnboardingView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct OnboardingView: View {
+  let pages: Int
+  var onFinish: () -> Void
+
+  @State private var currentPage = 0
+
+  var body: some View {
+    VStack {
+      TabView(selection: $currentPage) {
+        ForEach(0..<pages, id: \.self) { index in
+          VStack {
+            Spacer()
+            Text("Page \(index + 1)")
+              .font(.title)
+            Spacer()
+          }
+          .tag(index)
+        }
+      }
+      .tabViewStyle(.page)
+
+      HStack {
+        if currentPage > 0 {
+          Button("Back") {
+            withAnimation { currentPage -= 1 }
+          }
+        }
+        Spacer()
+        if currentPage < pages - 1 {
+          Button("Next") {
+            withAnimation { currentPage += 1 }
+          }
+        } else {
+          Button("Close") { onFinish() }
+        }
+      }
+      .padding()
+    }
+    .interactiveDismissDisabled()
+  }
+}
+
+#Preview {
+  OnboardingView(pages: 3, onFinish: {})
+}
+


### PR DESCRIPTION
## Summary
- add multi-page OnboardingView with basic navigation
- show onboarding on first launch and from Extras menu

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab29b8bad8832cac5a0a4aab38cb3e