### PR TITLE
Add onboarding skeleton modal

### DIFF
--- a/iOS/Managers/OverlayController.swift
+++ b/iOS/Managers/OverlayController.swift
@@ -1,0 +1,49 @@
+import CoreMorsel
+import SwiftUI
+import UIKit
+
+@MainActor
+final class OverlayController {
+  static let shared = OverlayController()
+  private var window: UIWindow?
+
+  func show() {
+    guard window == nil else { return }
+    let overlayWindow = UIWindow(frame: UIScreen.main.bounds)
+    overlayWindow.windowLevel = .alert + 1
+    overlayWindow.rootViewController = UIHostingController(rootView: OverlayMorselView())
+    overlayWindow.isHidden = false
+    window = overlayWindow
+  }
+
+  func hide() {
+    window?.isHidden = true
+    window = nil
+  }
+}
+
+private struct OverlayMorselView: View {
+  @ObservedObject private var appSettings = AppSettings.shared
+  @State private var shouldOpen = false
+  @State private var shouldClose = false
+  @State private var isChoosingDestination = false
+  @State private var destinationProximity: CGFloat = 0
+  @State private var isLookingUp = false
+
+  var body: some View {
+    MorselView(
+      shouldOpen: $shouldOpen,
+      shouldClose: $shouldClose,
+      isChoosingDestination: $isChoosingDestination,
+      destinationProximity: $destinationProximity,
+      isLookingUp: $isLookingUp,
+      morselColor: appSettings.morselColor,
+      onTap: {},
+      onAdd: { _ in }
+    )
+    .environmentObject(appSettings)
+    .allowsHitTesting(false)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+  }
+}
+

--- a/iOS/Managers/OverlayController.swift
+++ b/iOS/Managers/OverlayController.swift
@@ -5,20 +5,70 @@ import UIKit
 @MainActor
 final class OverlayController {
   static let shared = OverlayController()
-  private var window: UIWindow?
+  private var window: SelectiveHitWindow?
+  private weak var host: UIHostingController<OverlayMorselView>?
 
-  func show() {
+  func show(in windowScene: UIWindowScene) {
     guard window == nil else { return }
-    let overlayWindow = UIWindow(frame: UIScreen.main.bounds)
-    overlayWindow.windowLevel = .alert + 1
-    overlayWindow.rootViewController = UIHostingController(rootView: OverlayMorselView())
-    overlayWindow.isHidden = false
-    window = overlayWindow
+
+    let w = SelectiveHitWindow(windowScene: windowScene)
+    w.frame = windowScene.screen.bounds
+    w.windowLevel = .alert + 1
+    w.backgroundColor = .clear
+
+    let host = UIHostingController(rootView: OverlayMorselView())
+    host.view.backgroundColor = .clear
+    w.rootViewController = host
+
+    w.isHidden = false
+    w.makeKeyAndVisible()          // must be key to receive touches
+    self.window = w
+    self.host = host
+  }
+
+  func updateInteractiveRect(_ rectInWindow: CGRect?) {
+    guard let w = window else { return }
+    if let r = rectInWindow, !r.isNull, !r.isEmpty {
+      w.interactivePath = UIBezierPath(rect: r)
+    } else {
+      w.interactivePath = .init() // pass-through everywhere
+    }
+  }
+
+  // If you ever want a non-rect shape:
+  func updateInteractivePath(_ pathInWindow: UIBezierPath?) {
+    window?.interactivePath = pathInWindow ?? .init()
   }
 
   func hide() {
     window?.isHidden = true
+    window?.rootViewController = nil
     window = nil
+    host = nil
+  }
+}
+
+struct WindowFrameReporter: UIViewRepresentable {
+  let onChange: (CGRect?) -> Void
+
+  func makeUIView(context: Context) -> UIView {
+    let v = UIView(frame: .zero)
+    v.isUserInteractionEnabled = false
+    v.backgroundColor = .clear
+    return v
+  }
+
+  func updateUIView(_ view: UIView, context: Context) {
+    // Defer to next runloop so layout is final.
+    DispatchQueue.main.async {
+      guard let window = view.window else {
+        onChange(nil)
+        return
+      }
+      // Convert the reporter's bounds into window coordinates.
+      let frameInWindow = view.convert(view.bounds, to: window)
+      onChange(frameInWindow)
+    }
   }
 }
 
@@ -31,6 +81,7 @@ private struct OverlayMorselView: View {
   @State private var isLookingUp = false
 
   var body: some View {
+    // Full-screen layout, mascot pinned bottom
     MorselView(
       shouldOpen: $shouldOpen,
       shouldClose: $shouldClose,
@@ -38,12 +89,33 @@ private struct OverlayMorselView: View {
       destinationProximity: $destinationProximity,
       isLookingUp: $isLookingUp,
       morselColor: appSettings.morselColor,
-      onTap: {},
+      onTap: { /* mascot tap */ },
       onAdd: { _ in }
     )
     .environmentObject(appSettings)
-    .allowsHitTesting(false)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+    // Ensure only the mascot is hittable; everything else passes through
+    .background(
+      // Place the reporter exactly where the mascot actually draws.
+      // If MorselView has an internal container for the tappable area,
+      // attach the reporter *inside* that container instead.
+      WindowFrameReporter { rectInWindow in
+        OverlayController.shared.updateInteractiveRect(rectInWindow)
+      }
+      .frame(width: 1, height: 1) // tiny; just needs to share the same parent
+      .allowsHitTesting(false)
+      , alignment: .bottom // align with the mascot
+    )
   }
 }
+final class SelectiveHitWindow: UIWindow {
+  /// Window-space hit area. If empty, everything passes through.
+  var interactivePath: UIBezierPath = .init()
 
+  override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    interactivePath.contains(point)
+  }
+
+  // Optional: allow hardware keyboard to stay with underlying window.
+  override var canBecomeKey: Bool { true }
+}

--- a/iOS/MorselApp.swift
+++ b/iOS/MorselApp.swift
@@ -18,7 +18,9 @@ struct MorselApp: App {
 
   let notificationsManager = NotificationsManager()
 
-  init() {}
+  init() {
+    OverlayController.shared.show()
+  }
 
   var body: some Scene {
     WindowGroup {

--- a/iOS/MorselApp.swift
+++ b/iOS/MorselApp.swift
@@ -18,10 +18,6 @@ struct MorselApp: App {
 
   let notificationsManager = NotificationsManager()
 
-  init() {
-    OverlayController.shared.show()
-  }
-
   var body: some Scene {
     WindowGroup {
       ContentView(shouldOpenMouth: $shouldOpenMouth, shouldShowDigest: $shouldShowDigest, deepLinkDigestOffset: $digestOffset)
@@ -31,7 +27,8 @@ struct MorselApp: App {
         .onOpenURL { handleDeepLink($0) }
         .onAppear { launch() }
         .onChange(of: scenePhase) { _, phase in
-          if phase == .active {
+          if phase == .active, let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            OverlayController.shared.show(in: windowScene)
             notificationsManager.runCatchUpCheck()
           }
         }

--- a/iOS/Views/ContentView.swift
+++ b/iOS/Views/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
   @State private var recentlyDeleted: FoodEntry?
   @State private var showUndoToast = false
   @State private var undoWorkItem: DispatchWorkItem?
+  @State private var showOnboarding = false
 
   @Binding var shouldOpenMouth: Bool
   @Binding var shouldShowDigest: Bool
@@ -104,7 +105,12 @@ struct ContentView: View {
         .transition(.move(edge: .bottom).combined(with: .opacity))
       }
     }
-    .onAppear { onAppear() }
+    .onAppear {
+      onAppear()
+      if !hasSeenOnboarding {
+        showOnboarding = true
+      }
+    }
     .onReceive(NotificationPublishers.keyboardWillShow) { notification in
       if let height = extractKeyboardHeight(from: notification) {
         withAnimation {
@@ -134,6 +140,12 @@ struct ContentView: View {
     .onReceive(NotificationPublishers.appDidBecomeActive) { _ in }
     .onChange(of: entries.count) { _, new in updateWidget(newCount: new) }
     .statusBarHidden(shouldBlurBackground)
+    .sheet(isPresented: $showOnboarding) {
+      OnboardingView(pages: 3) {
+        hasSeenOnboarding = true
+        showOnboarding = false
+      }
+    }
   }
 }
 

--- a/iOS/Views/ContentView.swift
+++ b/iOS/Views/ContentView.swift
@@ -95,7 +95,6 @@ struct ContentView: View {
       }
     }
     .overlay(alignment: .top) { bottomBar }
-    .overlay(alignment: .bottom) { morsel }
     .overlay(alignment: .bottom) {
       if showUndoToast {
         UndoToastView {

--- a/iOS/Views/ExtrasView.swift
+++ b/iOS/Views/ExtrasView.swift
@@ -11,6 +11,7 @@ struct ExtrasView: View {
   @State private var showColorSheet = false
   @State private var showIconSheet = false
   @State private var showThemeSheet = false
+  @State private var showOnboarding = false
 
   var onClearAll: () -> Void
 
@@ -41,6 +42,13 @@ struct ExtrasView: View {
           icon: "questionmark.app.dashed",
           description: "Choose a different app icon for Morsel.",
           onTap: { showIconSheet = true }
+        )
+        CardView(
+          title: "",
+          value: "Onboarding",
+          icon: "info.circle",
+          description: "View the welcome screens again.",
+          onTap: { showOnboarding = true }
         )
         CardView(
           title: "",
@@ -122,6 +130,11 @@ struct ExtrasView: View {
         .onAppear {
           Analytics.track(ScreenViewIcon())
         }
+    }
+    .sheet(isPresented: $showOnboarding) {
+      OnboardingView(pages: 3) {
+        showOnboarding = false
+      }
     }
     .sheet(isPresented: $showThemeSheet) {
       ThemePickerView()

--- a/iOS/Views/OnboardingView.swift
+++ b/iOS/Views/OnboardingView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+@MainActor
+struct OnboardingView: View {
+  let pages: Int
+  var onFinish: () -> Void
+
+  @State private var currentPage = 0
+
+  var body: some View {
+    VStack {
+      TabView(selection: $currentPage) {
+        ForEach(0..<pages, id: \.self) { index in
+          VStack {
+            Spacer()
+            Text("Page \(index + 1)")
+              .font(.title)
+            Spacer()
+          }
+          .tag(index)
+        }
+      }
+      .tabViewStyle(.page)
+
+      HStack {
+        if currentPage > 0 {
+          Button("Back") {
+            withAnimation { currentPage -= 1 }
+          }
+        }
+        Spacer()
+        if currentPage < pages - 1 {
+          Button("Next") {
+            withAnimation { currentPage += 1 }
+          }
+        } else {
+          Button("Close") { onFinish() }
+        }
+      }
+      .padding()
+    }
+    .interactiveDismissDisabled()
+  }
+}
+
+#Preview {
+  OnboardingView(pages: 3, onFinish: {})
+}
+


### PR DESCRIPTION
## Summary
- add reusable onboarding modal with paging and navigation controls
- show onboarding on first launch
- allow relaunching onboarding from Extras menu
- annotate OnboardingView with `@MainActor`

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab29b8bad8832cac5a0a4aab38cb3e