### PR TITLE
Add onboarding skeleton

### DIFF
--- a/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
+++ b/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
@@ -236,7 +236,7 @@ public struct MorselView: View {
           perspective: 0.5
         )
         .scaleEffect(isBeingTouched ? CGSize(width: 0.9, height: 0.9) : CGSize(width: 1, height: 1))
-        .offset(isOpen ? .zero : idleOffset)
+        .offset(faceOffset)
     }
     .scaleEffect(isChoosingDestination || isOnboardingVisible ? 2 : 1)
     .padding(.bottom, 6)
@@ -255,6 +255,14 @@ public struct MorselView: View {
       if oldValue == false && newValue == true {
         close()
       }
+    }
+  }
+
+  var faceOffset: CGSize {
+    if isOnboardingVisible {
+      return CGSize(width: 0, height: -200)
+    } else {
+      return isOpen ? .zero : idleOffset
     }
   }
 
@@ -308,7 +316,7 @@ public struct MorselView: View {
               withAnimation {
                 isBeingTouched = false
               }
-              if !isChoosingDestination {
+              if !isChoosingDestination && !isOnboardingVisible {
                 onTap?()
 
                 if isOpen {

--- a/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
+++ b/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
@@ -110,6 +110,7 @@ public struct MorselView: View {
   @Binding var isChoosingDestination: Bool
   @Binding var destinationProximity: CGFloat
   @Binding var isLookingUp: Bool
+  @Binding var isOnboardingVisible: Bool
 
   @EnvironmentObject var appSettings: AppSettings
 
@@ -143,6 +144,7 @@ public struct MorselView: View {
     isChoosingDestination: Binding<Bool>,
     destinationProximity: Binding<CGFloat>,
     isLookingUp: Binding<Bool>,
+    isOnboardingVisible: Binding<Bool> = .constant(false),
     morselColor: Color,
     supportsOpen: Bool = true,
     onTap: (() -> Void)? = nil,
@@ -155,6 +157,7 @@ public struct MorselView: View {
     _isChoosingDestination = isChoosingDestination
     _destinationProximity = destinationProximity
     _isLookingUp = isLookingUp
+    _isOnboardingVisible = isOnboardingVisible
     self.morselColor = morselColor
     self.supportsOpen = supportsOpen
     self.onTap = onTap
@@ -235,6 +238,7 @@ public struct MorselView: View {
         .scaleEffect(isBeingTouched ? CGSize(width: 0.9, height: 0.9) : CGSize(width: 1, height: 1))
         .offset(isOpen ? .zero : idleOffset)
     }
+    .scaleEffect(isChoosingDestination || isOnboardingVisible ? 2 : 1)
     .padding(.bottom, 6)
     .onAppear {
       startBlinking()

--- a/iOS/Views/ContentView.swift
+++ b/iOS/Views/ContentView.swift
@@ -26,6 +26,7 @@ struct ContentView: View {
   @State private var showStats = false
   @State private var showExtras = false
   @State private var showDigest = false
+  @State private var showOnboarding = false
   @State private var shouldCloseMouth: Bool = false
   @State private var destinationProximity: CGFloat = 0
   @State private var destinationPickerHeight: CGFloat = 0
@@ -90,6 +91,21 @@ struct ContentView: View {
           withAnimation {
             showExtras = false
           }
+        } onShowOnboarding: {
+          withAnimation {
+            showExtras = false
+            showOnboarding = true
+          }
+        }
+      }
+    }
+    .overlay {
+      bottomPanelView(isVisible: showOnboarding) {
+        OnboardingView() {
+          withAnimation {
+            showOnboarding = false
+          }
+          hasSeenOnboarding = true
         }
       }
     }
@@ -228,7 +244,7 @@ private extension ContentView {
   }
 
   var shouldBlurBackground: Bool {
-    isKeyboardVisible || isChoosingDestination || showStats || showExtras
+    isKeyboardVisible || isChoosingDestination || showStats || showExtras || showOnboarding
   }
 }
 
@@ -240,6 +256,9 @@ private extension ContentView {
   func onAppear() {
     if shouldGenerateFakeData {
       generateFakeEntries()
+    }
+    if !hasSeenOnboarding {
+      showOnboarding = true
     }
     NotificationCenter.default.addObserver(
       forName: NSPersistentCloudKitContainer.eventChangedNotification,
@@ -405,6 +424,23 @@ private extension ContentView {
                 }
               }
           )
+      }
+    }
+  }
+
+  @ViewBuilder
+  func bottomPanelView<Content: View>(
+    isVisible: Bool,
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View {
+    ZStack {
+      if isVisible {
+        Color.black.opacity(0.25)
+          .ignoresSafeArea()
+        content()
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+          .transition(.move(edge: .bottom))
+          .animation(.spring(response: 0.4, dampingFraction: 0.7), value: isVisible)
       }
     }
   }

--- a/iOS/Views/ContentView.swift
+++ b/iOS/Views/ContentView.swift
@@ -166,6 +166,7 @@ private extension ContentView {
         isChoosingDestination: $isChoosingDestination,
         destinationProximity: $destinationProximity,
         isLookingUp: .constant(isLookingUp),
+        isOnboardingVisible: $showOnboarding,
         morselColor: appSettings.morselColor,
         onTap: {
           if showStats { withAnimation { showStats = false } }
@@ -176,7 +177,6 @@ private extension ContentView {
           withAnimation { isChoosingDestination = true }
         }
       )
-      .scaleEffect(isChoosingDestination ? 2 : 1)
       .frame(width: geo.size.width, height: geo.size.height, alignment: .bottom)
       .offset(y: offsetY)
       .animation(.spring(response: 0.4, dampingFraction: 0.8), value: offsetY)
@@ -195,7 +195,7 @@ private extension ContentView {
 
   @ViewBuilder
   var bottomBar: some View {
-    if !isKeyboardVisible && !isChoosingDestination {
+    if !isKeyboardVisible && !isChoosingDestination && !showOnboarding {
       BottomBarView(
         showStats: $showStats,
         showExtras: $showExtras,

--- a/iOS/Views/ExtrasView.swift
+++ b/iOS/Views/ExtrasView.swift
@@ -13,6 +13,7 @@ struct ExtrasView: View {
   @State private var showThemeSheet = false
 
   var onClearAll: () -> Void
+  var onShowOnboarding: () -> Void
 
 #if DEBUG
   @State private var showDebugMenu = false
@@ -55,6 +56,13 @@ struct ExtrasView: View {
           icon: "ellipsis.message",
           description: "Let us know how Morsel’s doing or what you'd like to see next.",
           onTap: { showFeedbackAlert = true }
+        )
+        CardView(
+          title: "",
+          value: "Onboarding",
+          icon: "rectangle.fill.on.rectangle.fill",
+          description: "View the onboarding again.",
+          onTap: { onShowOnboarding() }
         )
 #if DEBUG
         CardView(
@@ -150,6 +158,6 @@ struct ExtrasView: View {
 }
 
 #Preview {
-  ExtrasView(onClearAll: {})
+  ExtrasView(onClearAll: {}, onShowOnboarding: {})
     .background(Color(.systemGroupedBackground))
 }

--- a/iOS/Views/OnboardingView.swift
+++ b/iOS/Views/OnboardingView.swift
@@ -19,6 +19,7 @@ struct OnboardingView: View {
                 onClose()
               }
               .padding()
+              .padding(.bottom, 40)
             } else {
               Button("Next") {
                 withAnimation {

--- a/iOS/Views/OnboardingView.swift
+++ b/iOS/Views/OnboardingView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct OnboardingView: View {
+  var pages: [String] = ["Page 1", "Page 2", "Page 3"]
+  var onClose: () -> Void
+
+  @State private var currentPage = 0
+
+  var body: some View {
+    VStack {
+      TabView(selection: $currentPage) {
+        ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
+          VStack {
+            Spacer()
+            Text(page)
+            Spacer()
+            if index == pages.count - 1 {
+              Button("Close") {
+                onClose()
+              }
+              .padding()
+            } else {
+              Button("Next") {
+                withAnimation {
+                  currentPage = min(currentPage + 1, pages.count - 1)
+                }
+              }
+              .padding()
+            }
+          }
+          .tag(index)
+        }
+      }
+      .tabViewStyle(.page(indexDisplayMode: .always))
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color(.systemBackground))
+    .ignoresSafeArea()
+  }
+}
+
+#Preview {
+  OnboardingView(onClose: {})
+}


### PR DESCRIPTION
## Summary
- Add configurable onboarding view with paged navigation and close action
- Present onboarding from bottom overlay on first launch or via Extras
- Provide Extras card to reopen onboarding

## Testing
- `swift build` *(fails: no such module 'CommonCrypto', 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68ae15feb65c832c877339a2d66f9eda