### PR TITLE
Improve onboarding navigation and Morsel scaling

### DIFF
--- a/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
+++ b/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
@@ -111,6 +111,7 @@ public struct MorselView: View {
   @Binding var destinationProximity: CGFloat
   @Binding var isLookingUp: Bool
   @Binding var isOnboardingVisible: Bool
+  @Binding var onboardingPage: Double
 
   @EnvironmentObject var appSettings: AppSettings
 
@@ -145,6 +146,7 @@ public struct MorselView: View {
     destinationProximity: Binding<CGFloat>,
     isLookingUp: Binding<Bool>,
     isOnboardingVisible: Binding<Bool> = .constant(false),
+    onboardingPage: Binding<Double> = .constant(0),
     morselColor: Color,
     supportsOpen: Bool = true,
     onTap: (() -> Void)? = nil,
@@ -158,6 +160,7 @@ public struct MorselView: View {
     _destinationProximity = destinationProximity
     _isLookingUp = isLookingUp
     _isOnboardingVisible = isOnboardingVisible
+    _onboardingPage = onboardingPage
     self.morselColor = morselColor
     self.supportsOpen = supportsOpen
     self.onTap = onTap
@@ -238,7 +241,14 @@ public struct MorselView: View {
         .scaleEffect(isBeingTouched ? CGSize(width: 0.9, height: 0.9) : CGSize(width: 1, height: 1))
         .offset(faceOffset)
     }
-    .scaleEffect(isChoosingDestination || isOnboardingVisible ? 2 : 1)
+    .scaleEffect(
+      isChoosingDestination
+        ? 2
+        : isOnboardingVisible
+          ? max(1, min(2, 2 - 0.5 * onboardingPage))
+          : 1
+    )
+    .animation(.easeInOut(duration: 0.2), value: onboardingPage)
     .padding(.bottom, 6)
     .onAppear {
       startBlinking()

--- a/iOS/Views/ContentView.swift
+++ b/iOS/Views/ContentView.swift
@@ -27,6 +27,7 @@ struct ContentView: View {
   @State private var showExtras = false
   @State private var showDigest = false
   @State private var showOnboarding = false
+  @State private var onboardingPage: Double = 0
   @State private var shouldCloseMouth: Bool = false
   @State private var destinationProximity: CGFloat = 0
   @State private var destinationPickerHeight: CGFloat = 0
@@ -91,7 +92,7 @@ struct ContentView: View {
           withAnimation {
             showExtras = false
           }
-        } onShowOnboarding: {
+        } onShowWelcome: {
           withAnimation {
             showExtras = false
             showOnboarding = true
@@ -101,11 +102,12 @@ struct ContentView: View {
     }
     .overlay {
       bottomPanelView(isVisible: showOnboarding) {
-        OnboardingView() {
+        OnboardingView(page: $onboardingPage) {
           withAnimation {
             showOnboarding = false
           }
           hasSeenOnboarding = true
+          onboardingPage = 0
         }
       }
     }
@@ -167,6 +169,7 @@ private extension ContentView {
         destinationProximity: $destinationProximity,
         isLookingUp: .constant(isLookingUp),
         isOnboardingVisible: $showOnboarding,
+        onboardingPage: $onboardingPage,
         morselColor: appSettings.morselColor,
         onTap: {
           if showStats { withAnimation { showStats = false } }

--- a/iOS/Views/ExtrasView.swift
+++ b/iOS/Views/ExtrasView.swift
@@ -13,7 +13,7 @@ struct ExtrasView: View {
   @State private var showThemeSheet = false
 
   var onClearAll: () -> Void
-  var onShowOnboarding: () -> Void
+  var onShowWelcome: () -> Void
 
 #if DEBUG
   @State private var showDebugMenu = false
@@ -59,10 +59,10 @@ struct ExtrasView: View {
         )
         CardView(
           title: "",
-          value: "Onboarding",
-          icon: "rectangle.fill.on.rectangle.fill",
-          description: "View the onboarding again.",
-          onTap: { onShowOnboarding() }
+          value: "Welcome",
+          icon: "hand.wave",
+          description: "View the welcome again.",
+          onTap: { onShowWelcome() }
         )
 #if DEBUG
         CardView(
@@ -158,6 +158,6 @@ struct ExtrasView: View {
 }
 
 #Preview {
-  ExtrasView(onClearAll: {}, onShowOnboarding: {})
+  ExtrasView(onClearAll: {}, onShowWelcome: {})
     .background(Color(.systemGroupedBackground))
 }

--- a/iOS/Views/OnboardingView.swift
+++ b/iOS/Views/OnboardingView.swift
@@ -2,37 +2,87 @@ import SwiftUI
 
 struct OnboardingView: View {
   var pages: [String] = ["Page 1", "Page 2", "Page 3"]
+  @Binding var page: Double
   var onClose: () -> Void
 
   @State private var currentPage = 0
 
   var body: some View {
-    VStack {
-      TabView(selection: $currentPage) {
-        ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
-          VStack {
-            Spacer()
-            Text(page)
-            Spacer()
-            if index == pages.count - 1 {
-              Button("Close") {
+    GeometryReader { geo in
+      let width = geo.size.width
+
+      ZStack {
+        TabView(selection: $currentPage) {
+          ForEach(Array(pages.enumerated()), id: \.offset) { index, title in
+            VStack {
+              Spacer()
+              Text(title)
+              Spacer()
+            }
+            .tag(index)
+          }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .onChange(of: currentPage) { newValue in
+          withAnimation { page = Double(newValue) }
+        }
+        .simultaneousGesture(
+          DragGesture()
+            .onChanged { value in
+              let progress = Double(currentPage) - Double(value.translation.width / width)
+              page = min(max(progress, 0), Double(pages.count - 1))
+            }
+            .onEnded { _ in
+              page = Double(currentPage)
+            }
+        )
+
+        HStack {
+          Button {
+            withAnimation {
+              currentPage = max(currentPage - 1, 0)
+              page = Double(currentPage)
+            }
+          } label: {
+            Image(systemName: "chevron.left")
+              .frame(width: 44, height: 44)
+          }
+          .opacity(currentPage == 0 ? 0 : 1)
+
+          Spacer()
+
+          Button {
+            withAnimation {
+              if currentPage == pages.count - 1 {
                 onClose()
+              } else {
+                currentPage = min(currentPage + 1, pages.count - 1)
+                page = Double(currentPage)
               }
-              .padding()
-              .padding(.bottom, 40)
-            } else {
-              Button("Next") {
-                withAnimation {
-                  currentPage = min(currentPage + 1, pages.count - 1)
-                }
-              }
-              .padding()
+            }
+          } label: {
+            Image(systemName: currentPage == pages.count - 1 ? "xmark" : "chevron.right")
+              .frame(width: 44, height: 44)
+          }
+        }
+        .padding(.horizontal, 8)
+        .frame(width: geo.size.width, height: geo.size.height)
+        .foregroundStyle(.primary)
+
+        VStack {
+          Spacer()
+          HStack(spacing: 8) {
+            ForEach(0..<pages.count, id: \.self) { index in
+              Circle()
+                .fill(index == Int(round(page)) ? Color.primary : Color.primary.opacity(0.3))
+                .frame(width: 8, height: 8)
             }
           }
-          .tag(index)
+          .padding(.bottom, 24)
         }
+        .frame(width: geo.size.width, height: geo.size.height)
+        .foregroundStyle(.primary)
       }
-      .tabViewStyle(.page(indexDisplayMode: .always))
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color(.systemBackground))
@@ -41,5 +91,6 @@ struct OnboardingView: View {
 }
 
 #Preview {
-  OnboardingView(onClose: {})
+  OnboardingView(page: .constant(0), onClose: {})
 }
+


### PR DESCRIPTION
## Summary
- Add edge-aligned next/previous buttons and centered page dots for onboarding
- Rename extras menu item to "Welcome" with a waving hand icon
- Scale Morsel based on onboarding page progress

## Testing
- `swift build` *(fails: no such module 'CommonCrypto')*


------
https://chatgpt.com/codex/tasks/task_e_68af6ba6e2f4832cb3db29504761ea86