### PR TITLE
Enhance onboarding with branded content and Morsel animations

### DIFF
--- a/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
+++ b/CoreMorsel/Sources/CoreMorsel/UI/MorselView.swift
@@ -266,6 +266,25 @@ public struct MorselView: View {
         close()
       }
     }
+    .onChange(of: onboardingPage) { oldValue, newValue in
+      let oldPage = Int(round(oldValue))
+      let newPage = Int(round(newValue))
+      guard oldPage != newPage else { return }
+
+      switch newPage {
+      case 0:
+        withAnimation { isOpen = false }
+        isFocused = false
+        isSwallowingInternal = false
+      case 1:
+        withAnimation { isOpen = true }
+        isFocused = false
+      case 2:
+        close()
+      default:
+        break
+      }
+    }
   }
 
   var faceOffset: CGSize {

--- a/iOS/Views/OnboardingView.swift
+++ b/iOS/Views/OnboardingView.swift
@@ -1,7 +1,28 @@
 import SwiftUI
+import CoreMorsel
+
+private struct OnboardingPage {
+  let title: String
+  let message: String
+}
 
 struct OnboardingView: View {
-  var pages: [String] = ["Page 1", "Page 2", "Page 3"]
+  private let pages: [OnboardingPage] = [
+    OnboardingPage(
+      title: "Meet Morsel",
+      message: "Your mindful eating companion who helps you handle cravings."
+    ),
+    OnboardingPage(
+      title: "Feed Your Cravings",
+      message: "Tap Morsel when a craving hits and give it a name to stay aware."
+    ),
+    OnboardingPage(
+      title: "Digest Your Progress",
+      message: "Review patterns and celebrate wins in the Digest and Stats views."
+    )
+  ]
+
+  @EnvironmentObject var appSettings: AppSettings
   @Binding var page: Double
   var onClose: () -> Void
 
@@ -13,10 +34,16 @@ struct OnboardingView: View {
 
       ZStack {
         TabView(selection: $currentPage) {
-          ForEach(Array(pages.enumerated()), id: \.offset) { index, title in
-            VStack {
+          ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
+            VStack(spacing: 24) {
               Spacer()
-              Text(title)
+              Text(page.title)
+                .font(MorselFont.title)
+                .foregroundStyle(appSettings.morselColor)
+              Text(page.message)
+                .font(MorselFont.body)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
               Spacer()
             }
             .tag(index)
@@ -74,14 +101,17 @@ struct OnboardingView: View {
           HStack(spacing: 8) {
             ForEach(0..<pages.count, id: \.self) { index in
               Circle()
-                .fill(index == Int(round(page)) ? Color.primary : Color.primary.opacity(0.3))
+                .fill(
+                  index == Int(round(page))
+                    ? appSettings.morselColor
+                    : appSettings.morselColor.opacity(0.3)
+                )
                 .frame(width: 8, height: 8)
             }
           }
           .padding(.bottom, 24)
         }
         .frame(width: geo.size.width, height: geo.size.height)
-        .foregroundStyle(.primary)
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- Introduce structured onboarding pages styled with Morsel fonts and colors
- Animate Morsel through different states as users swipe pages

## Testing
- ⚠️ `swift build` *(no such module 'CommonCrypto')*

------
https://chatgpt.com/codex/tasks/task_e_68b014be958c832c9f011c2ce5ce1538