### PR TITLE
Add debug digest schedule override

### DIFF
--- a/iOS/Extensions/Calendar+Morsel.swift
+++ b/iOS/Extensions/Calendar+Morsel.swift
@@ -2,12 +2,22 @@ import Foundation
 
 extension Calendar {
   func startOfWeek(for date: Date) -> Date {
-    // Force ISO-8601 (Monday-start) weeks but keep the current timezone
     var cal = Calendar(identifier: .iso8601)
+    cal.firstWeekday = DigestConfiguration.weekStartWeekday
     cal.timeZone = self.timeZone
 
     let comps = cal.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+    guard let base = cal.date(from: comps) else { return date }
 
-    return cal.date(from: comps)!
+    var startComponents = cal.dateComponents([.year, .month, .day], from: base)
+    startComponents.hour = DigestConfiguration.weekStartHour
+    startComponents.minute = DigestConfiguration.weekStartMinute
+    startComponents.second = 0
+    guard let candidate = cal.date(from: startComponents) else { return base }
+
+    if candidate > date {
+      return cal.date(byAdding: .weekOfYear, value: -1, to: candidate) ?? candidate
+    }
+    return candidate
   }
 }

--- a/iOS/Features/Debug/DebugMenuView.swift
+++ b/iOS/Features/Debug/DebugMenuView.swift
@@ -6,6 +6,7 @@ import WidgetKit
 
 struct DebugMenuView: View {
   @State private var showStudio = false
+  @State private var showScheduleOverride = false
   private let notificationsManager = NotificationsManager()
   @Environment(\.modelContext) private var modelContext
 
@@ -19,6 +20,21 @@ struct DebugMenuView: View {
             icon: "timer",
             isFirst: true,
             onTap: { notificationsManager.scheduleDebugDigest() }
+          )
+          CardView(
+            title: "",
+            value: "Digest Schedule Override",
+            icon: "calendar.badge.clock",
+            onTap: { showScheduleOverride = true }
+          )
+          CardView(
+            title: "",
+            value: "Clear Digest Override",
+            icon: "arrow.clockwise",
+            onTap: {
+              DigestConfiguration.clearOverrides()
+              notificationsManager.rescheduleDigestNotifications()
+            }
           )
           CardView(
             title: "",
@@ -44,6 +60,9 @@ struct DebugMenuView: View {
         .padding(.top, 16)
       }
       .sheet(isPresented: $showStudio) { MorselStudio() }
+      .sheet(isPresented: $showScheduleOverride) {
+        NavigationStack { DigestScheduleOverrideView() }
+      }
     }
   }
 }

--- a/iOS/Features/Debug/DigestScheduleOverrideView.swift
+++ b/iOS/Features/Debug/DigestScheduleOverrideView.swift
@@ -1,0 +1,61 @@
+#if DEBUG
+import SwiftUI
+import Foundation
+
+struct DigestScheduleOverrideView: View {
+  @Environment(\.dismiss) private var dismiss
+  @State private var weekStartDay = DigestConfiguration.weekStartWeekday
+  @State private var weekStartTime = Calendar.current.date(
+    from: DateComponents(
+      hour: DigestConfiguration.weekStartHour,
+      minute: DigestConfiguration.weekStartMinute
+    )
+  ) ?? Date()
+  @State private var notificationDay = DigestConfiguration.unlockWeekday
+  @State private var notificationTime = Calendar.current.date(
+    from: DateComponents(
+      hour: DigestConfiguration.unlockHour,
+      minute: DigestConfiguration.unlockMinute
+    )
+  ) ?? Date()
+
+  private let notificationsManager = NotificationsManager()
+  private let calendar = Calendar.current
+
+  var body: some View {
+    Form {
+      Section("Weekly Reset") {
+        Picker("Weekday", selection: $weekStartDay) {
+          ForEach(1...7, id: \.self) { idx in
+            Text(calendar.weekdaySymbols[idx - 1]).tag(idx)
+          }
+        }
+        DatePicker("Time", selection: $weekStartTime, displayedComponents: .hourAndMinute)
+      }
+      Section("Digest Notification") {
+        Picker("Weekday", selection: $notificationDay) {
+          ForEach(1...7, id: \.self) { idx in
+            Text(calendar.weekdaySymbols[idx - 1]).tag(idx)
+          }
+        }
+        DatePicker("Time", selection: $notificationTime, displayedComponents: .hourAndMinute)
+      }
+      Button("Reschedule") { applyChanges() }
+    }
+    .navigationTitle("Digest Schedule")
+  }
+
+  private func applyChanges() {
+    let weekComps = calendar.dateComponents([.hour, .minute], from: weekStartTime)
+    let notifComps = calendar.dateComponents([.hour, .minute], from: notificationTime)
+    DigestConfiguration.setWeekStart(weekday: weekStartDay,
+                                     hour: weekComps.hour ?? 0,
+                                     minute: weekComps.minute ?? 0)
+    DigestConfiguration.setUnlock(weekday: notificationDay,
+                                  hour: notifComps.hour ?? 0,
+                                  minute: notifComps.minute ?? 0)
+    notificationsManager.rescheduleDigestNotifications()
+    dismiss()
+  }
+}
+#endif

--- a/iOS/Features/Digest/DigestModel.swift
+++ b/iOS/Features/Digest/DigestModel.swift
@@ -8,9 +8,44 @@ enum DigestAvailabilityState {
 }
 
 struct DigestConfiguration {
-  static let unlockWeekday = 2 // Monday
-  static let unlockHour = 12
-  static let unlockMinute = 15
+  private enum Keys {
+    static let unlockWeekday = "debug_digest_unlock_weekday"
+    static let unlockHour = "debug_digest_unlock_hour"
+    static let unlockMinute = "debug_digest_unlock_minute"
+    static let weekStartWeekday = "debug_digest_week_start_weekday"
+    static let weekStartHour = "debug_digest_week_start_hour"
+    static let weekStartMinute = "debug_digest_week_start_minute"
+  }
+
+  private static let defaults = UserDefaults.standard
+
+  static var unlockWeekday: Int { value(for: Keys.unlockWeekday, default: 2) }
+  static var unlockHour: Int { value(for: Keys.unlockHour, default: 12) }
+  static var unlockMinute: Int { value(for: Keys.unlockMinute, default: 15) }
+  static var weekStartWeekday: Int { value(for: Keys.weekStartWeekday, default: 2) }
+  static var weekStartHour: Int { value(for: Keys.weekStartHour, default: 0) }
+  static var weekStartMinute: Int { value(for: Keys.weekStartMinute, default: 0) }
+
+  static func clearOverrides() {
+    [Keys.unlockWeekday, Keys.unlockHour, Keys.unlockMinute, Keys.weekStartWeekday,
+     Keys.weekStartHour, Keys.weekStartMinute].forEach { defaults.removeObject(forKey: $0) }
+  }
+
+  static func setWeekStart(weekday: Int, hour: Int, minute: Int) {
+    defaults.set(weekday, forKey: Keys.weekStartWeekday)
+    defaults.set(hour, forKey: Keys.weekStartHour)
+    defaults.set(minute, forKey: Keys.weekStartMinute)
+  }
+
+  static func setUnlock(weekday: Int, hour: Int, minute: Int) {
+    defaults.set(weekday, forKey: Keys.unlockWeekday)
+    defaults.set(hour, forKey: Keys.unlockHour)
+    defaults.set(minute, forKey: Keys.unlockMinute)
+  }
+
+  private static func value(for key: String, default defaultValue: Int) -> Int {
+    defaults.object(forKey: key) == nil ? defaultValue : defaults.integer(forKey: key)
+  }
 }
 
 struct DigestModel {

--- a/iOS/Utilities/CalendarProvider.swift
+++ b/iOS/Utilities/CalendarProvider.swift
@@ -13,9 +13,21 @@ struct CalendarProvider: CalendarProviderInterface {
 
   func startOfWeek(for date: Date) -> Date {
     var calendar = Calendar(identifier: .iso8601)
-    calendar.firstWeekday = 2 // 2 = Monday
+    calendar.firstWeekday = DigestConfiguration.weekStartWeekday
+    calendar.timeZone = self.calendar.timeZone
 
     let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
-    return calendar.date(from: components)!
+    guard let base = calendar.date(from: components) else { return date }
+
+    var startComponents = calendar.dateComponents([.year, .month, .day], from: base)
+    startComponents.hour = DigestConfiguration.weekStartHour
+    startComponents.minute = DigestConfiguration.weekStartMinute
+    startComponents.second = 0
+    guard let candidate = calendar.date(from: startComponents) else { return base }
+
+    if candidate > date {
+      return calendar.date(byAdding: .weekOfYear, value: -1, to: candidate) ?? candidate
+    }
+    return candidate
   }
 }

--- a/iOS/Utilities/NotificationsManager.swift
+++ b/iOS/Utilities/NotificationsManager.swift
@@ -58,6 +58,10 @@ struct NotificationsManager {
     let request = UNNotificationRequest(identifier: debugDigestReminderId, content: content, trigger: trigger)
     UNUserNotificationCenter.current().add(request)
   }
+
+  func rescheduleDigestNotifications() {
+    scheduleDigestNotifications()
+  }
 }
 
 private extension NotificationsManager {


### PR DESCRIPTION
## Summary
- allow overriding digest week start and notification schedule
- add debug interface to change or clear digest schedule
- reschedule digest notifications when overrides change

## Testing
- `swiftformat --version` *(fails: command not found)*
- `swiftlint version` *(fails: command not found)*
- `swiftc -typecheck iOS/Features/Debug/DigestScheduleOverrideView.swift`
- `swiftc -typecheck iOS/Utilities/CalendarProvider.swift` *(fails: cannot find 'DigestConfiguration' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c06cf4ec7c832c81921bf13d75fb59